### PR TITLE
feat: app was opened flow trigger

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -3,6 +3,10 @@
     "en": "Fixes multiple issues regarding volume. Volume up/down/mute buttons and slider.",
     "nl": "Lost meerdere problemen op met betrekking tot het volume. Volume omhoog/naar beneden/dempen knoppen en volume slider."
   },
+  "0.4.0": {
+    "en": "New flow trigger: an app was opened",
+    "nl": "Nieuwe flow trigger: er is een app geopend"
+  },
   "0.3.7": {
     "en": "Fix the on/off detection crashing after a while",
     "nl": "Fix het vastlopen van de aan/uit detectie"

--- a/README.txt
+++ b/README.txt
@@ -1,32 +1,13 @@
 This app adds support for Philips TV's models ranging from ~2014 up to 2019 using the Jointspace protocol.
 Older models might need to manually enable this.
 
-Flow card actions that are currently available:
-- Turn on/off (device must have WOL enabled to turn on after long period of time)
-- Set volume
-- Mute/unmute volume
-- Send a key (send any key from your remote to the TV)
-- Open an app (only available from Android TV models)
-
-Flow card triggers that will soon be available:
-- Turned on/off
-- Volume changed
-- Open application changed
-
-Flow card actions that will soon be available:
-- Turn ambilight on/off
-- Turn ambilight + Hue on/off
-- Turn screen off
-
----
+## Features and fixes
+- On/off detection doesn't crash anymore
+- New flow trigger: "An app was opened"
+  (e.g. "Netflix" was opened)
 
 ## Known issues
-There are still some unresolved issues in the pairing process which is required for ~2016+ models. 
-I'm still looking into these.
-
-Another issue that I'm working on is that the app doesn't update the device's state after a while. 
-Because of this Flow card triggers like "Turned on/off" don't always work.
-
-If you're experiencing pairing issues or other bugs, please refer to the forum.
+There are still some unresolved issues in the pairing process. These are very hard to resolve, if you are experiencing
+these issues and want to contribute please contact me.
 
 https://community.athom.com/t/philips-tv-testing/14064

--- a/app.js
+++ b/app.js
@@ -33,24 +33,16 @@ class PhilipsTV extends Homey.App {
 
     async onFlowActionOpenApplication(args) {
         let device = args.device,
-            app = args.app,
-            client = device.getJointspaceClient();
+            app = args.app;
 
-        return client.launchActivity(app.intent);
+        return device.openApplication(app);
     }
 
     async onFlowApplicationAutocomplete(query, args) {
-        let device = args.device,
-            client = device.getJointspaceClient();
+        let device = args.device;
 
-        return client.getApplications().then(response => {
-            return response.applications.map(application => {
-                return {
-                    "id": application.id,
-                    "name": application.label,
-                    "intent": application.intent
-                }
-            }).filter(result => {
+        return device.getApplications().then(applications => {
+            return applications.filter(result => {
                 return result.name.toLowerCase().indexOf(query.toLowerCase()) > -1;
             });
         });

--- a/app.json
+++ b/app.json
@@ -127,16 +127,15 @@
       "icon": "drivers/philips-jointspace/assets/capabilities/hue.svg"
     },
     "current_application": {
-      "type": "enum",
-      "values": [],
+      "type": "string",
       "title": {
         "en": "Current app",
         "nl": "Huidige app"
       },
       "getable": true,
       "setable": true,
-      "uiComponent": "picker",
-      "uiQuickAction": true,
+      "uiComponent": null,
+      "uiQuickAction": false,
       "icon": "drivers/philips-jointspace/assets/capabilities/application.svg"
     },
     "key_stop": {
@@ -794,6 +793,32 @@
     }
   ],
   "flow": {
+    "triggers": [
+      {
+        "id": "application_opened",
+        "title": {
+          "en": "An app was opened",
+          "nl": "Er is een app geopend"
+        },
+        "tokens": [
+          {
+            "name": "app",
+            "type": "string",
+            "title": {
+              "en": "App"
+            },
+            "example": "Netflix"
+          }
+        ],
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=philips-jointspace"
+          }
+        ]
+      }
+    ],
     "actions": [
       {
         "id": "open_application",

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id": "codes.lucasvdh.philips-jointspace",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "compatibility": ">=1.5.0",
   "sdk": 2,
   "name": {

--- a/drivers/philips-jointspace/driver.js
+++ b/drivers/philips-jointspace/driver.js
@@ -24,11 +24,14 @@ class PhilipsJointSpaceDriver extends Homey.Driver {
             Homey.log('Philips TV - init device: ' + JSON.stringify(device_data));
             this.initDevice(device_data);
         });
+
         callback();
     }
 
     onInit() {
         this.log('MyDriver has been inited');
+
+        this.registerFlowCards();
 
         this.jointspaceClient = new JointspaceClient();
     }
@@ -266,6 +269,24 @@ class PhilipsJointSpaceDriver extends Homey.Driver {
             callback(error)
         }
 
+    }
+
+    registerFlowCards() {
+        this.applicationOpenedTrigger = new Homey.FlowCardTriggerDevice('application_opened')
+            .register();
+    }
+
+    triggerApplicationOpenedTrigger(device, args = {}) {
+        return this.triggerFlowCard(device, this.applicationOpenedTrigger, args);
+    }
+
+    triggerFlowCard(device, flowCardObject, args = {}) {
+        return new Promise((resolve, reject) => {
+            flowCardObject.trigger(device, args).then(resolve).catch(error => {
+                console.log(error);
+                reject(error);
+            });
+        })
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "philips-jointspace",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "dependencies": {
     "crypto": "^1.0.1",
     "https": "^1.0.0",


### PR DESCRIPTION
This PR contains the new flow trigger "An app was opened" which provides the app name as a token.

Resolves https://github.com/lucasvdh/codes.lucasvdh.philips-jointspace/issues/12